### PR TITLE
Improve speed of `scale_x`

### DIFF
--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -767,24 +767,22 @@
 
   double w_sum = sum(w);
   double m = w.size();
+  const double scale_denom = (m - 1) * w_sum / m;
 
-  for(uword i = 0; i < n_vars; i++) {
+  means = ( w.t() * x ).t() / w_sum;
 
-   means.at(i) = sum(w % x.col(i) ) / w_sum;
+  // subtract the mean now so you don't have to do the subtraction
+  // when computing standard deviation.
+  x.each_row() -= means.t();
 
-   // subtract the mean now so you don't have to do the subtraction
-   // when computing standard deviation.
-   x.col(i) -= means.at(i);
+  scales = sqrt(
+   ( w.t() * (x % x) ).t() / scale_denom
+  );
 
-   scales.at(i) = sqrt(
-    sum(w % pow(x.col(i), 2)) / ( (m-1) * w_sum / m )
-   );
+  uvec negative_scales = find(scales <= 0.0);
+  scales(negative_scales).ones(); // constant covariates;
 
-   if(scales(i) <= 0) scales.at(i) = 1.0; // constant covariate;
-
-   x.col(i) /= scales.at(i);
-
-  }
+  x.each_row() /= scales.t();
 
   return(x_transforms);
 

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -767,7 +767,6 @@
 
   double w_sum = sum(w);
   double m = w.size();
-  const double scale_denom = (m - 1) * w_sum / m;
 
   means = ( w.t() * x ).t() / w_sum;
 
@@ -776,7 +775,7 @@
   x.each_row() -= means.t();
 
   scales = sqrt(
-   ( w.t() * (x % x) ).t() / scale_denom
+   ( w.t() * (x % x) ).t() / ( (m - 1) * w_sum / m )
   );
 
   uvec negative_scales = find(scales <= 0.0);


### PR DESCRIPTION
The updated implementation is faster for taller matrices (1,000 rows or more). Below is the C++ code I used for benchmarking, as well as the results:

```Cpp
// [[Rcpp::depends(RcppArmadillo)]]
#include <RcppArmadillo.h>

using namespace arma;

// [[Rcpp::export]]
arma::mat scale_x(arma::mat& x,
                  arma::vec& w){

 uword n_vars = x.n_cols;

 mat x_transforms(n_vars, 2, fill::zeros);

 vec means  = x_transforms.unsafe_col(0);   // Reference to column 1
 vec scales = x_transforms.unsafe_col(1);   // Reference to column 2

 double w_sum = sum(w);
 double m = w.size();

 for(uword i = 0; i < n_vars; i++) {

  means.at(i) = sum(w % x.col(i) ) / w_sum;

  // subtract the mean now so you don't have to do the subtraction
  // when computing standard deviation.
  x.col(i) -= means.at(i);

  scales.at(i) = sqrt(
   sum(w % pow(x.col(i), 2)) / ( (m-1) * w_sum / m )
  );

  if(scales(i) <= 0) scales.at(i) = 1.0; // constant covariate;

  x.col(i) /= scales.at(i);

 }

 return(x_transforms);
}

// [[Rcpp::export]]
arma::mat new_scale_x(arma::mat& x,
                      arma::vec& w){

 uword n_vars = x.n_cols;

 mat x_transforms(n_vars, 2, fill::zeros);

 vec means  = x_transforms.unsafe_col(0);   // Reference to column 1
 vec scales = x_transforms.unsafe_col(1);   // Reference to column 2

 double w_sum = sum(w);
 double m = w.size();

 means = ( w.t() * x ).t() / w_sum;

 // subtract the mean now so you don't have to do the subtraction
 // when computing standard deviation.
 x.each_row() -= means.t();

 scales = sqrt(
  ( w.t() * (x % x) ).t() / ( (m - 1) * w_sum / m )
 );

 uvec negative_scales = find(scales <= 0.0);
 scales(negative_scales).ones(); // constant covariates;

 x.each_row() /= scales.t();

 return(x_transforms);
}

/*** R
library(data.table) # copy()

# new_scale_x is faster when matrix x is long, and it is especially fast when
# the matrix is also large.
NROW <- 1000L
NCOL <- 100L

set.seed(0L)
x <- rnorm(NROW * NCOL)
dim(x) <- c(NROW, NCOL)

w <- rep.int(1, NROW)

f1 <- function(x, w) {
 z <- copy(x)
 foo <- scale_x(z, w)
 return(z) # the centered and scaled x
}

f2 <- function(x, w) {
 z <- copy(x)
 foo <- new_scale_x(z, w)
 return(z)
}

res <- bench::mark(
 "scale_x" = f1(x, w),
 "new scale_x" = f2(x, w),
 iterations = 1e4L,
 relative = TRUE
)

res

plot(res)
*/
```


<img width="700" height="118" alt="image" src="https://github.com/user-attachments/assets/1e4e4229-6019-4d60-abe5-b35e4f653044" />

<img width="600" height="480" alt="image" src="https://github.com/user-attachments/assets/7b1ee261-8d26-4fae-8ca3-87f23a41001f" />

